### PR TITLE
Friendlier error page when curl request to Google fails

### DIFF
--- a/src/HTTP.hs
+++ b/src/HTTP.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
 module HTTP (
-  internalServerError
+  authenticationFailed
 , accessDenied
 ) where
 
@@ -11,10 +11,23 @@ import           Text.InterpolatedString.Perl6 (qc)
 import           Type
 import qualified Log
 
-internalServerError :: SendData -> String -> IO ()
-internalServerError send err = do
-  Log.error $ show err
-  simpleResponse send internalServerError500 [] "Internal Server Error"
+authenticationFailed :: SendData -> String -> IO ()
+authenticationFailed send err = do
+  Log.error err
+  simpleResponse send internalServerError500 [("Content-Type", "text/html")] [qc|
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Authentication Failed</title>
+  </head>
+  <body>
+  <h1>Authentication Failed</h1>
+    <p>Authentication Failed for an unknown reason.</p>
+    <p><a href="/">Try again!</a></p>
+  </body>
+</html>
+|]
 
 accessDenied :: SendData -> String -> IO ()
 accessDenied send email = simpleResponse send forbidden403 [("Content-Type", "text/html")] [qc|


### PR DESCRIPTION
On epsilon `epsilon.zalora.com` we have `CurlRecvError`s in the log:

```
$ journalctl -u sproxy | grep -i curl
Jun 26 11:55:29 epsilon sproxy[28368]: ThreadId 1931 2014-06-26 11:55:29.867038 UTC: "CurlRecvError -- "
Jun 30 09:55:05 epsilon sproxy[22163]: ThreadId 16351 2014-06-30 09:55:05.865014 UTC: "CurlRecvError -- "
Jul 02 08:42:29 epsilon sproxy[26915]: ThreadId 3908 2014-07-02 08:42:29.576161 UTC: "CurlRecvError -- "
Jul 03 00:58:26 epsilon sproxy[12194]: ThreadId 2181 2014-07-03 00:58:26.353712 UTC: "CurlRecvError -- "
Jul 03 00:58:51 epsilon sproxy[12194]: ThreadId 2278 2014-07-03 00:58:51.758973 UTC: "CurlRecvError -- "
Jul 03 08:07:11 epsilon sproxy[29771]: ThreadId 1134 2014-07-03 08:07:11.440935 UTC: "CurlRecvError -- "
Jul 03 10:59:44 epsilon sproxy[1391]: ThreadId 324 2014-07-03 10:59:44.926678 UTC: "CurlRecvError -- "
Jul 03 11:00:59 epsilon sproxy[1391]: ThreadId 324 2014-07-03 11:00:59.200204 UTC: "CurlRecvError -- "
Jul 04 01:40:41 epsilon sproxy[1391]: ThreadId 6433 2014-07-04 01:40:41.443064 UTC: "CurlRecvError -- "
Jul 07 07:22:50 epsilon sproxy[30466]: ThreadId 8748 2014-07-07 07:22:50.417006 UTC: "CurlRecvError -- "
```

I could not further track it down.  The occur relatively rarely.  For now I added a more friendly error page with a "retry" link.

We still have #38 and we should check how often those errors occur in the future.
